### PR TITLE
Fix for leap year check

### DIFF
--- a/strftime.js
+++ b/strftime.js
@@ -37,7 +37,7 @@ function strftime(sFormat, date) {
     aMonths = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
     aDayCount = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334],
     isLeapYear = function() {
-      if (nYear&3!==0) return false;
+      if ((nYear&3)!==0) return false;
       return nYear%100!==0 || nYear%400===0;
     },
     getThursday = function() {

--- a/strftime.js
+++ b/strftime.js
@@ -38,7 +38,7 @@ function strftime(sFormat, date) {
     aDayCount = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334],
     isLeapYear = function() {
       if (nYear&3!==0) return false;
-      return nYear%100!==0 || year%400===0;
+      return nYear%100!==0 || nYear%400===0;
     },
     getThursday = function() {
       var target = new Date(date);


### PR DESCRIPTION
The leap year check used an undefined variable, fixed it. Also added parens to make sure comparison is proper, at least TypeScript compiler complains about it.
